### PR TITLE
Add base configure support for loongarch64.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5146,6 +5146,11 @@ linux-gnu*|linux-musl*)
         EPM_FLAGS="-a hppa"
         PLATFORMID=linux_hppa
         ;;
+    loongarch64)
+        CPUNAME=LOONGARCH64
+        RTL_ARCH=LOONGARCH64
+        PLATFORMID=linux_loongarch64
+        ;;
     i*86)
         CPUNAME=INTEL
         RTL_ARCH=x86

--- a/solenv/gbuild/platform/LINUX_LOONGARCH64_GCC.mk
+++ b/solenv/gbuild/platform/LINUX_LOONGARCH64_GCC.mk
@@ -1,0 +1,16 @@
+# -*- Mode: makefile-gmake; tab-width: 4; indent-tabs-mode: t -*-
+#
+# This file is part of the LibreOffice project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+
+#please make generic modifications to unxgcc.mk or linux.mk
+gb_CPUDEFS += -DLOONGARCH64
+gb_COMPILEROPTFLAGS := -Os
+
+include $(GBUILDDIR)/platform/linux.mk
+
+# vim: set noet sw=4:


### PR DESCRIPTION
configure.ac : Add determine and configure for loongarch64 architecture.
LINUX_LOONGARCH64_GCC.mk : Add configuration of gcc compiler based on loongarch64 architecture.